### PR TITLE
Fix support message hook signature compatibility

### DIFF
--- a/kurumi_support_message/__init__.py
+++ b/kurumi_support_message/__init__.py
@@ -7,8 +7,13 @@ MESSAGE = "<span style='color: red;'>kurumi tokisaki supports passing of actuari
 DISPLAY_DURATION_MS = 5000
 
 
-def show_support_message(_mw):
-    """Display the Kurumi Tokisaki support message when Anki starts."""
+def show_support_message(_mw=None):
+    """Display the support message when Anki starts.
+
+    The hook signature changed in Anki 25.07 so the `_mw` argument became
+    optional. Accepting it as an optional parameter keeps compatibility with
+    both old and new versions of Anki.
+    """
     tooltip(MESSAGE, period=DISPLAY_DURATION_MS)
 
 


### PR DESCRIPTION
## Summary
- accept an optional main window argument when registering the support message hook so it works with Anki 25.07+
- document the compatibility change directly in the function docstring

## Testing
- python - <<'PY'
import importlib
import types
import sys

tooltip_calls = []

# Stub aqt.utils
utils_module = types.ModuleType("aqt.utils")

def tooltip(message, period=None):
    tooltip_calls.append((message, period))

utils_module.tooltip = tooltip
sys.modules["aqt.utils"] = utils_module

# Stub hook container
class DummyHook:
    def __init__(self):
        self.callbacks = []

    def append(self, func):
        self.callbacks.append(func)


dummy_hook = DummyHook()

gui_hooks_module = types.ModuleType("aqt.gui_hooks")
gui_hooks_module.main_window_did_init = dummy_hook
sys.modules["aqt.gui_hooks"] = gui_hooks_module

# Provide root aqt module so relative imports succeed
aqt_module = types.ModuleType("aqt")
aqt_module.gui_hooks = gui_hooks_module
aqt_module.utils = utils_module
sys.modules["aqt"] = aqt_module

addon = importlib.import_module("kurumi_support_message")

assert dummy_hook.callbacks, "Hook callback should be registered"
callback = dummy_hook.callbacks[0]

# Should work without mw argument (new Anki versions)
callback()

# Should also work with mw argument (older versions)
callback(object())

expected = (
    addon.MESSAGE,
    addon.DISPLAY_DURATION_MS,
)

assert tooltip_calls.count(expected) == 2, tooltip_calls
print("All assertions passed")
PY

------
https://chatgpt.com/codex/tasks/task_e_68dbb131c2bc8325a110b47e120292fd