### PR TITLE
Make Kurumi support message permanent

### DIFF
--- a/kurumi_support_message/__init__.py
+++ b/kurumi_support_message/__init__.py
@@ -1,19 +1,54 @@
 """Kurumi Tokisaki support message addon."""
 
+from typing import Optional
+
+from aqt import mw as main_window
 from aqt.gui_hooks import main_window_did_init
-from aqt.utils import tooltip
+from aqt.qt import QLabel, Qt
 
 MESSAGE = "<span style='color: red;'>Kurumi Tokisaki supports passing of actuarial practice CP1</span>"
+WIDGET_OBJECT_NAME = "kurumi_support_message_label"
 
 
-def show_support_message(_mw=None):
-    """Display the support message when Anki starts.
+def _remove_existing_label(parent) -> None:
+    """Remove a previously injected label if it exists.
 
-    The hook signature changed in Anki 25.07 so the `_mw` argument became
+    Re-adding the widget on subsequent hook invocations without removing the
+    old instance would lead to duplicated messages in the status bar.
+    """
+
+    for child in parent.findChildren(QLabel):
+        if child.objectName() == WIDGET_OBJECT_NAME:
+            parent.removeWidget(child)
+            child.deleteLater()
+
+
+def show_support_message(mw: Optional[object] = None) -> None:
+    """Display the support message in Anki's status bar when it starts.
+
+    The hook signature changed in Anki 25.07 so the ``mw`` argument became
     optional. Accepting it as an optional parameter keeps compatibility with
     both old and new versions of Anki.
     """
-    tooltip(MESSAGE, period=0)
+
+    if mw is None:
+        mw = main_window
+
+    if mw is None or not getattr(mw, "form", None):
+        return
+
+    status_bar = getattr(mw.form, "statusbar", None)
+    if status_bar is None:
+        return
+
+    _remove_existing_label(status_bar)
+
+    label = QLabel()
+    label.setObjectName(WIDGET_OBJECT_NAME)
+    label.setTextFormat(Qt.RichText)
+    label.setText(MESSAGE)
+
+    status_bar.addPermanentWidget(label)
 
 
 main_window_did_init.append(show_support_message)

--- a/kurumi_support_message/__init__.py
+++ b/kurumi_support_message/__init__.py
@@ -3,8 +3,7 @@
 from aqt.gui_hooks import main_window_did_init
 from aqt.utils import tooltip
 
-MESSAGE = "<span style='color: red;'>kurumi tokisaki supports passing of actuarial practice CP1</span>"
-DISPLAY_DURATION_MS = 5000
+MESSAGE = "<span style='color: red;'>Kurumi Tokisaki supports passing of actuarial practice CP1</span>"
 
 
 def show_support_message(_mw=None):
@@ -14,7 +13,7 @@ def show_support_message(_mw=None):
     optional. Accepting it as an optional parameter keeps compatibility with
     both old and new versions of Anki.
     """
-    tooltip(MESSAGE, period=DISPLAY_DURATION_MS)
+    tooltip(MESSAGE, period=0)
 
 
 main_window_did_init.append(show_support_message)


### PR DESCRIPTION
## Summary
- capitalize the Kurumi support message text
- make the tooltip stick around indefinitely to remove the timer

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dbb42bf86c83258dc4a9ca67a43a36